### PR TITLE
added INDEX / PERCENT type for COMMANDS

### DIFF
--- a/src/igloo.c
+++ b/src/igloo.c
@@ -18,20 +18,22 @@ static void list_befuddle(void)
     PRINT_TWO_COL("cat", "MIXED STRING", "salt", "MIXED");
     PRINT_TWO_COL("sub", "STRING STRING SIZE_T", "cut", "SIZE_T");
     PRINT_TWO_COL("rev", "NONE", "xor", "STRING");
-    PRINT_TWO_COL("replace", "STRING SIZE_T", "shuffle", "INT");
-    PRINT_TWO_COL("bshuffle", "INT INT", "ccipher", "INT");
-    PRINT_TWO_COL("rcipher", "INT", "complement", "NONE");
+    PRINT_TWO_COL("replace", "STRING SIZE_T", "shuffle", "SIZE_T");
+    PRINT_TWO_COL("ccipher", "INT", "rcipher", "SIZE_T");
+    PRINT_ONE_COL("complement", "NONE");
     PRINT_TWO_COL("genxor", "SIZE_T", "passwordify", "SIZE_T STRING");
     printf("\n%-80s\n", "meta befuddles:");
     PRINT_TWO_COL("fork", "NONE", "substr", "SIZE_T SIZE_T");
     PRINT_ONE_COL("join", "NONE");
+    PRINT_TWO_COL("iterate", "SIZE_T", "iterate_end", "NONE");
     printf("\n%-80s\n", "join befuddles:");
     PRINT_TWO_COL("cat", "MIXED COMMENT", "sub", "STRING COMMENT SIZE_T");
     PRINT_TWO_COL("xor", "COMMENT", "replace", "COMMENT SIZE_T");
-    printf("\n%-80s\n", "wolfssl befuddles:");
+    printf("\n%-80s\n", "hashes:");
     PRINT_TWO_COL("sha2-256", "NONE", "sha2-512", "NONE");
     PRINT_TWO_COL("sha3-256", "NONE", "sha3-512", "NONE");
-    PRINT_TWO_COL("blake2b", "NONE", "blake2s", "NONE");
+    PRINT_TWO_COL("blake2b", "SIZE_T", "blake2s", "SIZE_T");
+    PRINT_TWO_COL("shake128", "SIZE_T", "shake256", "SIZE_T");
 }
 
 static int parse_opt(int key, char *arg, struct argp_state *state)

--- a/src/igloo_befuddle.h
+++ b/src/igloo_befuddle.h
@@ -85,10 +85,10 @@ int bef_sha2_512(igloo_str *p);
 int bef_sha3_256(igloo_str *p);
 int bef_sha3_512(igloo_str *p);
 
-/* up to 64 byte digest */
-int bef_blake2b(igloo_str *p, size_t digest_size);
 /* up to 32 byte digest */
 int bef_blake2s(igloo_str *p, size_t digest_size);
+/* up to 64 byte digest */
+int bef_blake2b(igloo_str *p, size_t digest_size);
 
 /* digests with no limit on output size (technically 32 bit limit though) */
 int bef_shake128(igloo_str *p, size_t digest_size);

--- a/src/igloo_types.h
+++ b/src/igloo_types.h
@@ -34,8 +34,8 @@ enum igloo_cmd_type {
     IG_SHA2_512,
     IG_SHA3_256,
     IG_SHA3_512,
-    IG_BLAKE2B,
     IG_BLAKE2S,
+    IG_BLAKE2B,
     IG_SHAKE128,
     IG_SHAKE256,
 };
@@ -43,6 +43,8 @@ enum igloo_cmd_type {
 enum igloo_arg_type {
     INT,
     SIZE_T,
+    INDEX,
+    PERCENT,
     STRING,
     MIXED,
     NONE,

--- a/test.sh
+++ b/test.sh
@@ -133,9 +133,15 @@ echo "save/load profile tests -----------------------------"
 TEST_NAME="save test"
 [ -f "$PWD/test_profile" ] && rm -f "$PWD/test_profile"
 [ -f output.txt          ] && rm -f output.txt
-$VALGRIND ./igloo -q -s "$PWD/test_profile" "cat front igloo" "rev" <<< "igloo"
+$VALGRIND ./igloo -q -s "$PWD/test_profile" \
+    "cat front igloo" \
+    "rev" \
+    "substr 40% 8" \
+    "ccipher 0" \
+    "rcipher 1" \
+    'join cat\ front\ SUBSTR1' <<< "igloo"
 $VALGRIND ./igloo -q -l "$PWD/test_profile" <<< "igloo" > output.txt
-check_file_error "output.txt" "oolgioolgi"
+check_file_error "output.txt" "iooloolgioolgi"
 [ -f "$PWD/test_profile" ] && rm -f "$PWD/test_profile"
 echo ""
 
@@ -198,9 +204,14 @@ verify "igloo" "cut 4" \
        "oiglo"
 echo ""
 
-TEST_NAME="cut at middle"
-verify "igloo" "cut 0" \
-       "looig"
+TEST_NAME="cut with percent (26%)"
+verify "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN" "cut 26%" \
+       "defghijklmnopqrstuvwxyzABCDEFGHIJKLMN0123456789abc"
+echo ""
+
+TEST_NAME="cut with percent (75%)"
+verify "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN" "cut 75%" \
+       "BCDEFGHIJKLMN0123456789abcdefghijklmnopqrstuvwxyzA"
 echo ""
 
 echo "REV tests -------------------------------------------"
@@ -239,6 +250,11 @@ echo ""
 TEST_NAME="replace at end"
 verify "igloo" "replace snow 5" \
        "igloosnow"
+echo ""
+
+TEST_NAME="replace from percent (58%)"
+verify "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN" "replace snow 58%" \
+       "0123456789abcdefghijklmnopqrssnowxyzABCDEFGHIJKLMN"
 echo ""
 
 echo "SHUFFLE tests ---------------------------------------"
@@ -408,6 +424,21 @@ verify "igloo" 'substr 0 5, join cat\ front\ SUBSTR1' \
        "iglooigloo"
 echo ""
 
+TEST_NAME="substr with percents (23%, 69%)"
+verify "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN" 'substr 23% 68%, join cat\ front\ SUBSTR1' \
+       "bcdefghijklmnopqrstuvwx0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN"
+echo ""
+
+TEST_NAME="substr with half percent 1 (23%, 48)"
+verify "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN" 'substr 23% 48, join cat\ front\ SUBSTR1' \
+       "bcdefghijklmnopqrstuvwxyzABCDEFGHIJKL0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN"
+echo ""
+
+TEST_NAME="substr with half percent 2 (5, 48%)"
+verify "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN" 'substr 5 48%, join cat\ front\ SUBSTR1' \
+       "56789abcdefghijklmn0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN"
+echo ""
+
 echo "JOIN tests ------------------------------------------"
 TEST_NAME="join with cat"
 verify "igloo" 'fork, join cat\ front\ FORK1' \
@@ -479,16 +510,6 @@ verify_hash "igloo" "sha3-512" \
             "f86598196d636286da077b8f9310f817f1b90a9882e3ba62039d0d2fe3a099ef3473e19d6f807eac210f03b7047c68f8c0903042d53552ee22c87b76f66a01710a"
 echo ""
 
-TEST_NAME="blake2b test (1 byte)"
-verify_hash "igloo" "blake2b 1" \
-            "9d0a"
-echo ""
-
-TEST_NAME="blake2b test (64 bytes)"
-verify_hash "igloo" "blake2b 64" \
-            "d6e46c104e35834919ab9ba83b2b7b75fc7705b44a48b8e43400a7513970b3180fef90c3c1c7bd3d2fa3c852d5155fb1c14ea3dbf31ac7e1800dd4d0ddb1be840a"
-echo ""
-
 TEST_NAME="blake2s test (1 byte)"
 verify_hash "igloo" "blake2s 1" \
             "520a"
@@ -497,6 +518,16 @@ echo ""
 TEST_NAME="blake2s test (32 bytes)"
 verify_hash "igloo" "blake2s 32" \
             "173e7f73fa204f2bf6ad0588403f608f7231d578a21e1b3e63ef1be37ceb2f6f0a"
+echo ""
+
+TEST_NAME="blake2b test (1 byte)"
+verify_hash "igloo" "blake2b 1" \
+            "9d0a"
+echo ""
+
+TEST_NAME="blake2b test (64 bytes)"
+verify_hash "igloo" "blake2b 64" \
+            "d6e46c104e35834919ab9ba83b2b7b75fc7705b44a48b8e43400a7513970b3180fef90c3c1c7bd3d2fa3c852d5155fb1c14ea3dbf31ac7e1800dd4d0ddb1be840a"
 echo ""
 
 TEST_NAME="shake128 test (1 byte)"


### PR DESCRIPTION
Certain commands (cut, replace, substr) previously took SIZE_T as argument(s), representing an index. Using indices on potentially unknown length passwords is fairly primitive so PERCENT has been added to remedy this.

The commands using SIZE_T as an index have had this argument converted to INDEX.
An INDEX type may be converted to a PERCENT type at 'parse-time' by suffixing an integer with '%'.